### PR TITLE
Minor log message fix

### DIFF
--- a/src/AspNetCore.Authentication.JwtBearer/DPoP/DefaultDPoPProofValidator.cs
+++ b/src/AspNetCore.Authentication.JwtBearer/DPoP/DefaultDPoPProofValidator.cs
@@ -477,7 +477,7 @@ public class DefaultDPoPProofValidator : IDPoPProofValidator
 
         if (IsExpired(context, result, time, ExpirationValidationMode.Nonce))
         {
-            Logger.LogDebug("DPoP 'nonce' expiration failed. It's possible that the server farm clocks might not be closely synchronized, so consider setting the ServerClockSkew on the DPoPOptions on the IdentityServerOptions.");
+            Logger.LogDebug("DPoP 'nonce' expired. Issuing new value to client.");
 
             result.SetError("Invalid 'nonce' value.", OidcConstants.TokenErrors.UseDPoPNonce);
             result.ServerIssuedNonce = CreateNonce(context, result);


### PR DESCRIPTION
We have an inaccurate log message when dpop nonces are used - it is normal for them to expire and be regenerated by the api, but our log message makes it sound like there is a clock skew issue. Also, it is copy-pasted from identity server and refers to identity server's configs.