### PR TITLE
Use new signing certificate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,11 @@ jobs:
             dotnet NuGetKeyVaultSignTool sign "$file" \
                 --file-digest sha256 \
                 --timestamp-rfc3161 http://timestamp.digicert.com \
-                --azure-key-vault-url https://duendecodesigning.vault.azure.net/ \
+                --azure-key-vault-url https://duendecodesigninghsm.vault.azure.net/ \
                 --azure-key-vault-client-id 18e3de68-2556-4345-8076-a46fad79e474 \
                 --azure-key-vault-tenant-id ed3089f0-5401-4758-90eb-066124e2d907 \
                 --azure-key-vault-client-secret ${{ secrets.SignClientSecret }} \
-                --azure-key-vault-certificate CodeSigning
+                --azure-key-vault-certificate NuGetPackageSigning
         done
 
     - name: Push packages


### PR DESCRIPTION
Closes #17

Background: we recently updated the code signing certificate that we use on all of our packages. This change is the same as what we did for the products and foss repos.