### PR TITLE
Avoid duplicate access token parsing

### DIFF
--- a/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
+++ b/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
@@ -82,7 +82,7 @@ public class DPoPJwtBearerEvents : JwtBearerEvents
                 Scheme = context.Scheme.Name,
                 ProofToken = proofToken,
                 AccessToken = at,
-                AccessTokenClaims = parsedToken?.Claims ?? [],
+                AccessTokenClaims = context.Principal?.Claims ?? parsedToken?.Claims ?? [],
                 Method = context.HttpContext.Request.Method,
                 Url = context.HttpContext.Request.Scheme + "://" + context.HttpContext.Request.Host + context.HttpContext.Request.PathBase + context.HttpContext.Request.Path
             });

--- a/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
+++ b/src/AspNetCore.Authentication.JwtBearer/DPoP/DPoPJwtBearerEvents.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.Net.Http.Headers;
 using static IdentityModel.OidcConstants;
 
@@ -73,16 +72,12 @@ public class DPoPJwtBearerEvents : JwtBearerEvents
                 throw new InvalidOperationException("Missing DPoP (proof token) HTTP header");
             }
 
-            // TODO - Add support for introspection
-            var handler = new JsonWebTokenHandler();
-            var parsedToken = handler.ReadJsonWebToken(at);
-
             var result = await _validator.Validate(new DPoPProofValidationContext
             {
                 Scheme = context.Scheme.Name,
                 ProofToken = proofToken,
                 AccessToken = at,
-                AccessTokenClaims = context.Principal?.Claims ?? parsedToken?.Claims ?? [],
+                AccessTokenClaims = context.Principal?.Claims ?? [],
                 Method = context.HttpContext.Request.Method,
                 Url = context.HttpContext.Request.Scheme + "://" + context.HttpContext.Request.Host + context.HttpContext.Request.PathBase + context.HttpContext.Request.Path
             });


### PR DESCRIPTION
There is no need to parse the access token in the DPoPJwtBearerEvents, since the handler already parses and makes the claims available in the context. By relying on those claims, we improve both performance (no allocation of an extra parser, no duplication of parsing work) and functionality (claims from a JWE are available).

This PR is based on @jpda's work using the claims in the context. I go a little further by just not parsing at all. The reason to create a new PR is to rebase the changes onto main, where CI pipeline updates have been merged that are needed for the build.